### PR TITLE
add compatibility with Bitbucket Server git urls

### DIFF
--- a/src/com/squareup/intellij/helper/StashRepo.java
+++ b/src/com/squareup/intellij/helper/StashRepo.java
@@ -27,6 +27,12 @@ public class StashRepo extends GitRepo {
     String project = chunks[1].toUpperCase();
     String repo = chunks[2];
 
+    // bitbucket server urls might be like "http://domain.com/scm/project/repo.git"
+    if(project.equals("SCM")) {
+      project = chunks[2].toUpperCase();
+      repo = chunks[3];
+    }
+
     return "https://" + Joiner.on('/').join(domain, "projects", project, "repos", repo, "browse");
   }
 


### PR DESCRIPTION
The extra /scm/ in the git url was causing trouble for my stash/Bitbucket Server installation. This fixes it.
