### PR TITLE
Generate correct URL to STASH sources from origin

### DIFF
--- a/src/com/squareup/intellij/helper/GitRepo.java
+++ b/src/com/squareup/intellij/helper/GitRepo.java
@@ -2,6 +2,7 @@
 package com.squareup.intellij.helper;
 
 import com.google.common.annotations.VisibleForTesting;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileFilter;
@@ -31,7 +32,7 @@ public abstract class GitRepo {
   public abstract String brand();
 
   /* Implement for different repository systems. */
-  abstract String buildUrlFor(String sanitizedUrlValue);
+  abstract String buildUrlFor(String originUrl);
 
   abstract String buildLineDomainPrefix();
 
@@ -40,7 +41,7 @@ public abstract class GitRepo {
   }
 
   public String repoUrlFor(String filePath, Integer line) {
-    filePath = filePath.replaceFirst(gitConfigFile.getParentFile().getParent(), "");
+    filePath = filePath.replaceFirst(Pattern.quote(gitConfigFile.getParentFile().getParent()), "");
     return gitBaseUrl() + filePath + (line != null ? buildLineDomainPrefix() + line : "");
   }
 
@@ -76,9 +77,7 @@ public abstract class GitRepo {
         }
         matcher = URL_VALUE.matcher(line);
         if (inRemoteOriginSection && matcher.matches()) {
-          return buildUrlFor(matcher.group(1)
-              .replaceAll("ssh://|git://|git@|https://", "")
-              .replaceAll(":", "/"));
+          return buildUrlFor(matcher.group(1));
         }
       }
       throw new RuntimeException("Did not find [remote \"origin\"] url set in " + gitConfigFile);

--- a/src/com/squareup/intellij/helper/GithubRepo.java
+++ b/src/com/squareup/intellij/helper/GithubRepo.java
@@ -18,8 +18,11 @@ public class GithubRepo extends GitRepo {
   }
 
   @Override
-  protected String buildUrlFor(String sanitizedUrlValue) {
-    return "https://" + sanitizedUrlValue + "/blob/master";
+  protected String buildUrlFor(String originUrl) {
+    final String domainAndContextpath = originUrl
+            .replaceAll("ssh://|git://|git@|https://", "")
+            .replaceAll(":", "/");
+    return "https://" + domainAndContextpath + "/blob/master";
 
   }
 

--- a/src/com/squareup/intellij/helper/StashRepo.java
+++ b/src/com/squareup/intellij/helper/StashRepo.java
@@ -2,6 +2,10 @@ package com.squareup.intellij.helper;
 
 import com.google.common.base.Joiner;
 
+import java.net.URI;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+
 /**
  * Url builder for atlassian stash repos.
  */
@@ -21,13 +25,15 @@ public class StashRepo extends GitRepo {
   }
 
   @Override
-  protected String buildUrlFor(String sanitizedUrlValue) {
-    String[] chunks = sanitizedUrlValue.split("/");
-    String domain = chunks[0];
-    String project = chunks[1].toUpperCase();
-    String repo = chunks[2];
-
-    return "https://" + Joiner.on('/').join(domain, "projects", project, "repos", repo, "browse");
+  protected String buildUrlFor(String originUrl) {
+    final String domainAndPath = originUrl.replaceAll("ssh://|git://|git@|https://", "");
+    final String[] domainAndPathParts = domainAndPath.split("/");
+    final ArrayDeque<String> partDeque = new ArrayDeque<String>(Arrays.asList(domainAndPathParts));
+    final String repo = partDeque.pollLast();
+    final String project = partDeque.pollLast().toUpperCase();
+    final String domainAndContextPath = Joiner.on("/").join(partDeque);
+    final String browsePath = Joiner.on('/').join(domainAndContextPath, "projects", project, "repos", repo, "browse");
+    return URI.create("https://" + browsePath).toASCIIString();
   }
 
   @Override

--- a/test/com/squareup/intellij/GitRepoTest.java
+++ b/test/com/squareup/intellij/GitRepoTest.java
@@ -7,6 +7,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+
 import static org.junit.Assert.assertEquals;
 
 public class GitRepoTest {
@@ -14,7 +17,10 @@ public class GitRepoTest {
 
   @Test
   public void github_parsesSshGitConfig_git_ro__with_line() throws Exception {
-    GithubRepo repo = new GithubRepo(".", "test/test_github_gitconfig_git_ro.txt");
+    final String projectRoot = givenProjectRoot();
+
+    final GithubRepo repo = new GithubRepo(projectRoot, "test/test_github_gitconfig_git_ro.txt");
+
     assertEquals(
         "https://git.squareup.com/square/java/blob/master/projectX/src/main/java/com/ex/Ex.java#L30",
         repo.repoUrlFor("/projectX/src/main/java/com/ex/Ex.java", 30)
@@ -23,7 +29,10 @@ public class GitRepoTest {
 
   @Test
   public void github_parsesSshGitConfig_git_ro() throws Exception {
-    GithubRepo repo = new GithubRepo(".", "test/test_github_gitconfig_git_ro.txt");
+    final String projectRoot = givenProjectRoot();
+
+    final GithubRepo repo = new GithubRepo(projectRoot, "test/test_github_gitconfig_git_ro.txt");
+
     assertEquals(
         "https://git.squareup.com/square/java/blob/master/projectX/src/main/java/com/ex/Ex.java",
         repo.repoUrlFor("/projectX/src/main/java/com/ex/Ex.java")
@@ -32,7 +41,9 @@ public class GitRepoTest {
 
   @Test
   public void github_parsesSshGitConfig_https() throws Exception {
-    GithubRepo repo = new GithubRepo(".", "test/test_github_gitconfig_https.txt");
+    final String projectRoot = givenProjectRoot();
+
+    final GithubRepo repo = new GithubRepo(projectRoot, "test/test_github_gitconfig_https.txt");
     assertEquals(
         "https://git.squareup.com/square/java/blob/master/projectX/src/main/java/com/ex/Ex.java",
         repo.repoUrlFor("/projectX/src/main/java/com/ex/Ex.java")
@@ -41,7 +52,10 @@ public class GitRepoTest {
 
   @Test
   public void invalidGitConfig() throws Exception {
-    GithubRepo repo = new GithubRepo(".", "test/test_github_gitconfig_invalid.txt");
+    final String projectRoot = givenProjectRoot();
+
+    final GithubRepo repo = new GithubRepo(projectRoot, "test/test_github_gitconfig_invalid.txt");
+
     expectedException.expect(RuntimeException.class);
     expectedException.expectMessage("Did not find");
     repo.repoUrlFor("/projectX/src/main/java/com/ex/Ex.java");
@@ -49,7 +63,10 @@ public class GitRepoTest {
 
   @Test
   public void github_parsesSshGitConfig() throws Exception {
-    GithubRepo repo = new GithubRepo(".", "test/test_github_gitconfig_ssh.txt");
+    final String projectRoot = givenProjectRoot();
+
+    final GithubRepo repo = new GithubRepo(projectRoot, "test/test_github_gitconfig_ssh.txt");
+
     assertEquals(
         "https://git.squareup.com/square/java/blob/master/projectX/src/main/java/com/ex/Ex.java",
         repo.repoUrlFor("/projectX/src/main/java/com/ex/Ex.java")
@@ -58,7 +75,10 @@ public class GitRepoTest {
 
   @Test
   public void github_parsesSshGitConfig_comments() throws Exception {
-    GithubRepo repo = new GithubRepo(".", "test/test_github_gitconfig_ssh_comments.txt");
+    final String projectRoot = givenProjectRoot();
+
+    final GithubRepo repo = new GithubRepo(projectRoot, "test/test_github_gitconfig_ssh_comments.txt");
+
     assertEquals(
         "https://git.squareup.com/square/java/blob/master/projectX/src/main/java/com/ex/Ex.java",
         repo.repoUrlFor("/projectX/src/main/java/com/ex/Ex.java")
@@ -67,7 +87,10 @@ public class GitRepoTest {
 
   @Test
   public void github_parsesSshGitConfig_variation() throws Exception {
-    GithubRepo repo = new GithubRepo(".", "test/test_github_gitconfig_ssh_variation.txt");
+    final String projectRoot = givenProjectRoot();
+
+    final GithubRepo repo = new GithubRepo(projectRoot, "test/test_github_gitconfig_ssh_variation.txt");
+
     assertEquals(
         "https://git.squareup.com/square/java/blob/master/projectX/src/main/java/com/ex/Ex.java",
         repo.repoUrlFor("/projectX/src/main/java/com/ex/Ex.java")
@@ -76,10 +99,29 @@ public class GitRepoTest {
 
   @Test
   public void stash_parsesSshGitConfig() throws Exception {
-    StashRepo repo = new StashRepo(".", "test/test_stash_gitconfig_ssh.txt");
+    final String projectRoot = givenProjectRoot();
+
+    final StashRepo repo = new StashRepo(projectRoot, "test/test_stash_gitconfig_ssh.txt");
+
     assertEquals(
-        "https://git.corp.squareup.com/projects/SQ/repos/docs/browse/projectX/src/main/java/com/ex/Ex.java",
+        "https://git.corp.squareup.com:7770/projects/SQ/repos/docs/browse/projectX/src/main/java/com/ex/Ex.java",
         repo.repoUrlFor("/projectX/src/main/java/com/ex/Ex.java")
     );
+  }
+
+  @Test
+  public void stash_parsesSshWithContextPathGitConfig() throws Exception {
+    final String projectRoot = givenProjectRoot();
+
+    final StashRepo repo = new StashRepo(projectRoot, "test/test_stash_gitconfig_ssh_with_context_path.txt");
+
+    assertEquals(
+        "https://git.corp.squareup.com:7770/SCM/projects/SQ/repos/docs/browse/projectX/src/main/java/com/ex/Ex.java",
+        repo.repoUrlFor("/projectX/src/main/java/com/ex/Ex.java")
+    );
+  }
+
+  private String givenProjectRoot() throws URISyntaxException, MalformedURLException {
+    return getClass().getResource(".").toURI().getSchemeSpecificPart();
   }
 }

--- a/test/test_stash_gitconfig_ssh_with_context_path.txt
+++ b/test/test_stash_gitconfig_ssh_with_context_path.txt
@@ -6,7 +6,7 @@
         ignorecase = true
 [remote "origin"]
         fetch = +refs/heads/*:refs/remotes/origin/*
-        url = ssh://git@git.corp.squareup.com:7770/sq/docs.git
+        url = ssh://git@git.corp.squareup.com:7770/SCM/sq/docs.git
         tagopt = --no-tags
 [branch "master"]
         remote = origin


### PR DESCRIPTION
Fixes the issue with wrong URLs to Bitbucket Servers when running on special port.
It also fixes the problem with running Bitbucket Servers on a context path other than `/`.
To make it run, i had to make the file paths compatible with Windows systems, because that is what i use at home, but not at work ;). So the string is escaped before applying the regex pattern and the tests use proper URIs to the test files.
